### PR TITLE
Ceiling for calculating set offset

### DIFF
--- a/pp0.html
+++ b/pp0.html
@@ -99,7 +99,7 @@
 
             this.createSetHeads = function (sets, ways) {
                 var unshuffledArray = new Uint32Array(sets / SETS_PER_PAGE);
-                var allSetOffset = Math.log2(sets) + 4; // 17 for sets=8192, 16 for sets=4096
+                var allSetOffset = Math.ceil(Math.log2(sets)) + 4; // 17 for sets=8192, 16 for sets=4096
                 var i;
                 for (i = 0; i < unshuffledArray.length; i++) {
                     unshuffledArray[i] = i;


### PR DESCRIPTION
This pull request is to follow up to my initial email, which I will summarize below.

### Issue observed
My colleagues and I could reproduce the cache occupancy channel on an i7-7600U (4 MiB LLC, 16 ways * 4096 sets), but not on an i7-9750H and i7-10710U (both 12 MiB LLC, 16 ways * 12288 sets).

### Changes
`Math.log2(12288)` in line 102 did not result in an integer. The fix is simply to enclose it in `Math.ceil()`, and we were able to reproduce pp0 subsequently.